### PR TITLE
Add metadata.template to azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -3,10 +3,9 @@ metadata:
   subscription: ${AZURE_SUBSCRIPTION_ID}
   location: ${AZURE_LOCATION}
   resource_group: ${AZURE_RESOURCE_GROUP}
-
+  template: azd-mcp-csharp@0.0.1-beta
 infra:
   bicep: ./infra/main.bicep
-
 services:
   mcpserver:
     project: ./src/mcpserver


### PR DESCRIPTION
Adds  `metadata.template` tag for azd template discovery and telemetry tracking.

This is a minimal change generated by template-doctor validation tooling.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>